### PR TITLE
selection area fixed

### DIFF
--- a/src/components/Forms/_FormElement.js
+++ b/src/components/Forms/_FormElement.js
@@ -1,6 +1,19 @@
-import React from "react";
+import React,{useState} from "react";
 
 const FormElement = ({ Label, Value, Type, onChange, onSwitch, ImageHandler }) => {
+  const [fix,setfix] = useState("");
+  const hoverClick=()=>{
+      onSwitch();
+      if (fix === "") {
+        setfix("yes");
+      }
+      else {
+        setfix("");
+      }
+  }
+
+
+
   return (
     <div className="rezume-forms-item">
       {(() => {
@@ -36,13 +49,13 @@ const FormElement = ({ Label, Value, Type, onChange, onSwitch, ImageHandler }) =
           case "Switch":
             return (
               <div className="form-check form-switch">
-                <div>
+                <div className="" onClick={hoverClick}>
                   <input
                     className="form-check-input"
                     type="checkbox"
                     role="switch"
                     id="flexSwitchCheckDefault"
-                    onChange={onSwitch}
+                    checked={fix}
                   />
                   <label className="form-check-label">
                     Add profile picture


### PR DESCRIPTION
## Issue that this pull request solves
Increase the clickable area for Profile Pic checkbox 

Closes: # (issue number)
#135 

## Proposed changes

Brief description of what is fixed or changed
I changed the clickable area for the add profile picture checkbox button so it becomes easy for the user to select it .

## Types of changes

_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (Documentation content changed)
- [ ] Other (please describe): 

## Checklist

_Put an `x` in the boxes that apply_

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

## Screenshots

Please attach the screenshots of the changes made in case of change in user interface
![Screenshot (4)](https://user-images.githubusercontent.com/111674354/215096630-b041fc50-63ce-4add-8d20-3c6c8b6aff87.png)
[screen-capture (11).webm](https://user-images.githubusercontent.com/111674354/215096654-5dae1160-081d-4cd6-be86-c35c0d572565.webm)


## Other information

Any other information that is important to this pull request